### PR TITLE
feat: add modular turtleprize2 miner

### DIFF
--- a/turtleprize2/const.lua
+++ b/turtleprize2/const.lua
@@ -1,0 +1,27 @@
+-- Constants and configuration for turtleprize2
+-- Shared by turtle, central computer, and pocket programs
+
+local M = {}
+
+-- Valuable ores table: true for ores we want to mine
+M.valuableOres = {
+  ["allthemodium:allthemodium_ore"] = true,
+  ["allthemodium:vibranium_ore"] = true,
+  ["allthemodium:unobtainium_ore"] = true,
+  ["minecraft:diamond_ore"] = true,
+  ["minecraft:deepslate_diamond_ore"] = true,
+  ["minecraft:emerald_ore"] = true,
+  ["minecraft:ancient_debris"] = true,
+  ["minecraft:nether_quartz_ore"] = true,
+}
+
+-- Network protocol name
+M.protocol = "turtleprize2"
+
+-- Rednet message types
+M.msg = {
+  status = "status",      -- turtle -> controller, inventory and position
+  recall = "recall",      -- controller -> turtle, return to base
+}
+
+return M

--- a/turtleprize2/controller.lua
+++ b/turtleprize2/controller.lua
@@ -1,0 +1,58 @@
+-- Central controller for turtleprize2
+-- target: computer (supports external monitors)
+-- Displays inventory stats for each turtle and allows recall via touch
+
+package.path = package.path .. ";/?.lua;/?/init.lua"
+
+local const = require("turtleprize2.const")
+local util = require("turtleprize2.util")
+local net = require("turtleprize2.net")
+
+net.open()
+
+local monitor = peripheral.find("monitor")
+if monitor then
+  monitor.setTextScale(0.5)
+  term.redirect(monitor)
+end
+
+local turtles = {} -- id -> status
+
+local function redraw()
+  term.clear()
+  term.setCursorPos(1,1)
+  print("TurtlePrize2 Controller")
+  print("Click a turtle to recall")
+  local row = 3
+  for id,st in pairs(turtles) do
+    local line = string.format("%d: fuel %d items %d", id, st.fuel or 0, st.total or 0)
+    print(line)
+    st._row = row
+    row = row + 1
+  end
+end
+
+redraw()
+
+while true do
+  local e = {os.pullEvent()}
+  if e[1] == "rednet_message" then
+    local id,msg = e[2], e[3]
+    if msg.type == const.msg.status then
+      local st = turtles[id] or {}
+      st.total = msg.data.total or 0
+      st.fuel = msg.data.fuel or 0
+      st.pos = msg.data.pos
+      turtles[id] = st
+      redraw()
+    end
+  elseif e[1] == "monitor_touch" then
+    local x,y = e[3], e[4]
+    for id,st in pairs(turtles) do
+      if st._row == y then
+        net.send(id, const.msg.recall, true)
+      end
+    end
+  end
+  util.yield()
+end

--- a/turtleprize2/geoscanner.lua
+++ b/turtleprize2/geoscanner.lua
@@ -1,0 +1,25 @@
+-- Wrapper around Advanced Peripherals geoscanner
+-- Requires a geoScanner peripheral on the turtle
+-- target: turtle
+
+local const = require("turtleprize2.const")
+local M = {}
+
+-- Find geoscanner peripheral
+local scanner = peripheral.find("geoScanner")
+
+-- returns table of valuable ores in scan radius
+function M.findValuables(radius)
+  if not scanner then return {} end
+  local ok, data = pcall(scanner.scan, radius or 8)
+  if not ok or not data then return {} end
+  local found = {}
+  for _,block in ipairs(data) do
+    if const.valuableOres[block.name] then
+      table.insert(found, block)
+    end
+  end
+  return found
+end
+
+return M

--- a/turtleprize2/inventory.lua
+++ b/turtleprize2/inventory.lua
@@ -1,0 +1,60 @@
+-- Inventory management for turtleprize2 turtles
+-- target: turtle
+
+local const = require("turtleprize2.const")
+local net = require("turtleprize2.net")
+local util = require("turtleprize2.util")
+
+local M = {}
+
+-- Summarize current inventory counts for valuable ores
+function M.summary()
+  local sums = {}
+  local total = 0
+  for i=1,16 do
+    local item = turtle.getItemDetail(i)
+    if item then
+      total = total + item.count
+      if const.valuableOres[item.name] then
+        sums[item.name] = (sums[item.name] or 0) + item.count
+      end
+    end
+  end
+  return {total = total, ores = sums, fuel = turtle.getFuelLevel()}
+end
+
+-- Broadcast status over network to controller
+function M.report(pos)
+  local status = M.summary()
+  status.pos = pos
+  net.broadcast(const.msg.status, status)
+end
+
+-- Drop non-valuable items
+function M.dropJunk()
+  for i=1,16 do
+    local item = turtle.getItemDetail(i)
+    if item and not const.valuableOres[item.name] then
+      turtle.select(i)
+      turtle.drop()
+      util.yield()
+    end
+  end
+end
+
+-- deposit items into ender chest if present in front
+function M.depositToEnder()
+  local ok, data = turtle.inspect()
+  if ok and data.name == "minecraft:ender_chest" then
+    for i=1,16 do
+      turtle.select(i)
+      turtle.drop()
+      util.yield()
+    end
+    turtle.select(1)
+    return true
+  end
+  return false
+end
+
+return M

--- a/turtleprize2/miner.lua
+++ b/turtleprize2/miner.lua
@@ -1,0 +1,105 @@
+-- Mining turtle program for turtleprize2
+-- target: turtle (Advanced Peripherals: geoScanner, Chunky Turtle)
+-- Requires modem, pickaxe and optional chunk loader/ender chest
+
+package.path = package.path .. ";/?.lua;/?/init.lua"
+
+local const = require("turtleprize2.const")
+local util = require("turtleprize2.util")
+local net = require("turtleprize2.net")
+local geo = require("turtleprize2.geoscanner")
+local inv = require("turtleprize2.inventory")
+
+net.open() -- open modem
+
+-- determine starting position via GPS
+local function getPos()
+  local x,y,z = gps.locate(5)
+  if x then return {x=x,y=y,z=z} end
+  return nil
+end
+
+local home = getPos()
+
+-- simple refuel routine using any fuel in inventory
+local function refuel()
+  if turtle.getFuelLevel() > 200 then return true end
+  for i=1,16 do
+    if turtle.getItemCount(i) > 0 then
+      turtle.select(i)
+      if turtle.refuel(0) then
+        turtle.refuel(turtle.getItemCount(i))
+        turtle.select(1)
+        return true
+      end
+    end
+  end
+  turtle.select(1)
+  return false
+end
+
+-- move one block forward digging if needed
+local function forward()
+  while not turtle.forward() do
+    turtle.dig()
+    util.yield()
+  end
+end
+
+-- dig any valuable ore adjacent to turtle
+local function mineAdjacent()
+  local ores = geo.findValuables(8)
+  for _,o in ipairs(ores) do
+    if o.x==0 and o.y==0 and o.z==1 then
+      turtle.dig(); return true
+    elseif o.x==0 and o.y==1 and o.z==0 then
+      turtle.digUp(); return true
+    elseif o.x==0 and o.y==-1 and o.z==0 then
+      turtle.digDown(); return true
+    elseif o.x==1 and o.y==0 and o.z==0 then
+      turtle.turnRight(); turtle.dig(); turtle.turnLeft(); return true
+    elseif o.x==-1 and o.y==0 and o.z==0 then
+      turtle.turnLeft(); turtle.dig(); turtle.turnRight(); return true
+    end
+  end
+  return false
+end
+
+-- main mining loop
+while true do
+  if not refuel() then
+    net.broadcast(const.msg.status, {error = "out_of_fuel"})
+    break
+  end
+
+  inv.report(getPos())
+
+  -- check for recall commands
+  local id,msg = net.receive(0.1)
+  if msg and msg.type == const.msg.recall then
+    break
+  end
+
+  if not mineAdjacent() then
+    turtle.dig()
+    forward()
+  end
+
+  inv.dropJunk()
+  if inv.summary().total > 14*64 then
+    inv.depositToEnder()
+  end
+  util.yield()
+end
+
+-- ascend to surface if GPS home is known
+if home then
+  while true do
+    local pos = getPos()
+    if not pos or pos.y >= home.y then break end
+    while not turtle.up() do turtle.digUp(); util.yield() end
+  end
+end
+
+inv.report(getPos())
+print("Miner stopped")

--- a/turtleprize2/net.lua
+++ b/turtleprize2/net.lua
@@ -1,0 +1,41 @@
+-- Networking helpers using rednet for turtleprize2
+-- Any device with a modem can use this module
+
+local const = require("turtleprize2.const")
+
+local M = {}
+
+-- Ensure a modem is open for rednet
+function M.open()
+  if rednet.isOpen() then return true end
+  for _,side in ipairs(rs.getSides()) do
+    if peripheral.getType(side) == "modem" then
+      rednet.open(side)
+      return true
+    end
+  end
+  return false
+end
+
+-- Send a message to id using protocol
+function M.send(id, typ, data)
+  if not M.open() then return false end
+  local msg = {type = typ, data = data}
+  return rednet.send(id, msg, const.protocol)
+end
+
+-- Broadcast message to all computers
+function M.broadcast(typ, data)
+  if not M.open() then return false end
+  local msg = {type = typ, data = data}
+  rednet.broadcast(msg, const.protocol)
+end
+
+-- Receive message, returns sender and table
+function M.receive(timeout)
+  if not M.open() then return nil end
+  local id, msg = rednet.receive(const.protocol, timeout)
+  return id, msg
+end
+
+return M

--- a/turtleprize2/pocket.lua
+++ b/turtleprize2/pocket.lua
@@ -1,0 +1,45 @@
+-- Pocket computer display for turtleprize2
+-- target: pocket
+-- Shows current status of turtles
+
+package.path = package.path .. ";/?.lua;/?/init.lua"
+
+local const = require("turtleprize2.const")
+local util = require("turtleprize2.util")
+local net = require("turtleprize2.net")
+
+net.open()
+local turtles = {}
+
+local function redraw()
+  term.clear()
+  term.setCursorPos(1,1)
+  print("TurtlePrize2 Pocket")
+  local row = 3
+  for id,st in pairs(turtles) do
+    print(string.format("%d: fuel %d items %d", id, st.fuel or 0, st.total or 0))
+    st._row = row
+    row = row + 1
+  end
+end
+
+redraw()
+
+while true do
+  local e = {os.pullEvent()}
+  if e[1] == "rednet_message" then
+    local id,msg = e[2], e[3]
+    if msg.type == const.msg.status then
+      turtles[id] = msg.data
+      redraw()
+    end
+  elseif e[1] == "touch" then
+    local x,y = e[2], e[3]
+    for id,st in pairs(turtles) do
+      if st._row == y then
+        net.send(id, const.msg.recall, true)
+      end
+    end
+  end
+  util.yield()
+end

--- a/turtleprize2/util.lua
+++ b/turtleprize2/util.lua
@@ -1,0 +1,16 @@
+-- Utility helpers for turtleprize2
+-- Works on computer, turtle and pocket
+
+local M = {}
+
+-- simple wrapper around sleep to avoid blocking
+function M.yield()
+  sleep(0)
+end
+
+-- Wait for an event, optionally filtering
+function M.pull(event)
+  return os.pullEvent(event)
+end
+
+return M


### PR DESCRIPTION
## Summary
- start turtleprize2 modular miner with geoscanner integration
- add central controller and pocket display for monitoring and recalls
- implement inventory utilities and networking helpers
- ensure modules load on ComputerCraft and add recall on pocket display

## Testing
- `luac -p turtleprize2/*.lua`

------
https://chatgpt.com/codex/tasks/task_e_6898db931ea4832fb5b26f397556276a